### PR TITLE
Use protocol from `this._ws.protocol` only if it is defined

### DIFF
--- a/src/wampy.js
+++ b/src/wampy.js
@@ -652,8 +652,9 @@
 
         this._log('[wampy] websocket connected');
 
-        p = this._ws.protocol.split('.');
-        this._options.transportEncoding = p[2];
+        if (this._ws.protocol) {
+            this._options.transportEncoding = this._ws.protocol.split('.')[2];
+        }
 
         if (this._options.transportEncoding === 'msgpack') {
             this._ws.binaryType = 'arraybuffer';


### PR DESCRIPTION
Fixes #8