### PR TITLE
Main module change

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mocha": "^3.2.0",
     "mocha-lcov-reporter": "^1.2.0"
   },
-  "main": "src/wampy.js",
+  "main": "build/wampy.js",
   "dependencies": {
     "msgpack5": "^3.4.1",
     "websocket": "^1.0.24"


### PR DESCRIPTION
i had issue while running tests via phantomjs
```
Unexpected token 'const' at /spec_bundle.js:25056 <- webpack:///~/wampy/src/wampy.js:33:0
```
i've noticed that `main` directs to the source code instead of builded version 
and phantom (and i'm sure not only phantom) can't handle es6
so i changed `src/wampy.js` to the `build/wampy.js`