### PR TITLE
Limit generated ID's on some bigger number than 55

### DIFF
--- a/dist/wampy.js
+++ b/dist/wampy.js
@@ -331,7 +331,7 @@ var Wampy = function () {
         key: '_getReqId',
         value: function _getReqId() {
             var reqId = void 0;
-            var max = 2 ^ 53;
+            var max = Math.pow(2, 53);
 
             do {
                 reqId = Math.floor(Math.random() * max);

--- a/src/wampy.js
+++ b/src/wampy.js
@@ -310,7 +310,7 @@ class Wampy {
      */
     _getReqId () {
         let reqId;
-        const max = 2 ^ 53;
+        const max = Math.pow(2, 53);
 
         do {
             reqId = Math.floor(Math.random() * max);


### PR DESCRIPTION
The ^ operation in javascript means XOR and not 'raise to the power of'.
In busy situations this caused webapps to hang because all ID's below 55
were in use.