### PR TITLE
persist advancedOptions for potential auto reconnect

### DIFF
--- a/src/wampy.js
+++ b/src/wampy.js
@@ -773,7 +773,8 @@ class Wampy {
                         if (this._requests[data[1]]) {
                             this._subscriptions[this._requests[data[1]].topic] = this._subscriptions[data[2]] = {
                                 id: data[2],
-                                callbacks: [this._requests[data[1]].callbacks.onEvent]
+                                callbacks: [this._requests[data[1]].callbacks.onEvent],
+                                advancedOptions: this._requests[data[1]].advancedOptions
                             };
 
                             this._subsTopics.add(this._requests[data[1]].topic);
@@ -1058,7 +1059,7 @@ class Wampy {
         for (let topic of st) {
             i = subs[topic].callbacks.length;
             while (i--) {
-                this.subscribe(topic, subs[topic].callbacks[i]);
+                this.subscribe(topic, subs[topic].callbacks[i], subs[topic].advancedOptions);
             }
         }
     }
@@ -1245,7 +1246,8 @@ class Wampy {
 
             this._requests[reqId] = {
                 topic: topicURI,
-                callbacks
+                callbacks,
+                advancedOptions
             };
 
             // WAMP SPEC: [SUBSCRIBE, Request|id, Options|dict, Topic|uri]


### PR DESCRIPTION
### Description, Motivation and Context
Fix for #100 

### What is the current behavior? 
Subscriptions that are made with advancedOptions are not re-applied after a re-connect

### What is the new behavior?
The advancedOption is persisted with the subscription and can be re-applied on reconnect

### What kind of change does this PR introduce?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] Overall test coverage is not decreased.
- [ ] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
