### PR TITLE
Fix _isPlainObject

### DIFF
--- a/src/wampy.js
+++ b/src/wampy.js
@@ -382,10 +382,41 @@ class Wampy {
      * @private
      */
     _isPlainObject (obj) {
-        return  typeof obj === 'object' // separate from primitives
-                && obj !== null         // is obvious
-                && obj.constructor === Object // separate instances (Array, DOM, ...)
-                && Object.prototype.toString.call(obj) === '[object Object]'; // separate build-in like Math
+        if (!this._isObject(obj)) {
+            return false;
+        }
+
+        // If has modified constructor
+        const ctor = obj.constructor;
+        if (typeof ctor !== 'function') {
+            return false;
+        }
+
+        // If has modified prototype
+        const prot = ctor.prototype;
+        if (this._isObject(prot) === false) {
+            return false;
+        }
+
+        // If constructor does not have an Object-specific method
+        if (prot.hasOwnProperty('isPrototypeOf') === false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if value is an object
+     * @param obj
+     * @returns {boolean}
+     * @private
+     */
+    _isObject (obj) {
+        return  obj !== null
+                && typeof obj === 'object'
+                && Array.isArray(obj) === false
+                && Object.prototype.toString.call(obj) === '[object Object]';
     }
 
     /**


### PR DESCRIPTION
### Description, Motivation and Context

Fixes #97 - In Node environment, `obj.constructor === Object` was returning `false`, perhaps due to some overload or monkey patch?

Based on jonschlinkert/is-plain-object.

### What is the current behavior? 
#97  - In Node env, default settings were used, regardless of what options were passed into constructor

### What kind of change does this PR introduce?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed. (except crossbar, untested)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
