### PR TITLE
Fix msgpack support.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,8 @@ module.exports = function (grunt) {
                     transform: [['babelify', { 'presets': ['es2015'] }]]
                 },
                 files  : {
-                    'dist/browser/wampy.js': 'src/browser.js'
+                    'dist/browser/wampy.js': 'src/browser.js',
+                    'dist/browser/msgpacksrlzr.js': 'src/msgpacksrlzrbrowser.js'
                 }
             }
         },
@@ -38,7 +39,8 @@ module.exports = function (grunt) {
             },
             dist4Browser: {
                 files: {
-                    'dist/browser/wampy.min.js': ['dist/browser/wampy.js']
+                    'dist/browser/wampy.min.js': ['dist/browser/wampy.js'],
+                    'dist/browser/msgpacksrlzr.min.js': ['dist/browser/msgpacksrlzr.js']
                 }
             }
         },
@@ -52,7 +54,11 @@ module.exports = function (grunt) {
         },
         concat: {
             concatWampyMsgpack: {
-                src: ['dist/browser/msgpack5.min.js', 'dist/browser/wampy.min.js'],
+                src: [
+                    'dist/browser/msgpack5.min.js',
+                    'dist/browser/msgpacksrlzr.min.js',
+                    'dist/browser/wampy.min.js'
+                ],
                 dest: 'dist/browser/wampy-all.min.js'
             }
         },

--- a/src/msgpacksrlzrbrowser.js
+++ b/src/msgpacksrlzrbrowser.js
@@ -1,0 +1,6 @@
+/**
+ * Wrapper for browser usage of MsgpackSerializer
+ * Set window global variable
+ **/
+import { MsgpackSerializer } from './serializers/MsgpackSerializer';
+window.MsgpackSerializer = MsgpackSerializer;

--- a/src/wampy.js
+++ b/src/wampy.js
@@ -35,7 +35,7 @@ class Wampy {
          * @type {string}
          * @private
          */
-        this.version = 'v5.0.1';
+        this.version = 'v5.0.2';
 
         /**
          * WS Url
@@ -520,7 +520,7 @@ class Wampy {
             throw new Error('Binary type is not allowed: ' + type);
         }
 
-        this._ws.binatyType = type;
+        this._ws.binaryType = type;
 
         // WAMP SPEC: [HELLO, Realm|uri, Details|dict]
         // Sending directly 'cause it's a hello msg and no sessionId check is needed


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description, Motivation and Context
I needed IE support so I cannot use the most recent v6.x releases. When I tried to use the msgpack support in v5.0.1 in a browser context, MsgpackSerializer was undefined. After fixing that in the build process, enabling Msgpack threw an exception which I then fixed.

### What is the current behavior? 
Msgpack support does not work in the browser for v5.0.1.

### What is the new behavior?
Msgpack support works.

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [X] Overall test coverage is not decreased.
- [X] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
