### PR TITLE
add publisher_identification to subscriber.features as per spec

### DIFF
--- a/src/wampy.js
+++ b/src/wampy.js
@@ -69,7 +69,8 @@ class Wampy {
                 subscriber: {
                     features: {
                         pattern_based_subscription: true,
-                        publication_trustlevels   : true
+                        publication_trustlevels   : true,
+                        publisher_identification  : true
                     }
                 },
                 caller    : {


### PR DESCRIPTION
For the [Nexus](https://github.com/gammazero/nexus) WAMP router to provide
publisher identification info to subscribers, it requires that 'publisher-identification' be true
in the subscriber.features in the right place in the JSON. I am not an author on Nexus.

[publisher-identification](https://wamp-proto.org/_static/gen/wamp_latest.html#publisher-identification)


My reading of the spec supports that it is truly needed in the features in the HELLO,
to enable passing of the sessionid in the 'details.publisher' field of pubsub messages.

[Feature Announcement of publisher_identification](https://wamp-proto.org/_static/gen/wamp_latest.html#feature-announcement-11)


I am thrilled to be using Wampy, thanks to all the great coders who worked on it!