### PR TITLE
README has confusing old 5.x examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Usage example
 
 ```javascript
 const ws = new Wampy('/ws/', { realm: 'AppRealm' });
-ws.subscribe('system.monitor.update', function (dataArr, dataObj) { console.log('Received system.monitor.update event!'); })
-  .subscribe('client.message', function (dataArr, dataObj) { console.log('Received client.message event!'); })
+ws.subscribe('system.monitor.update', function (dataArr) { console.log('Received system.monitor.update event!'); })
+  .subscribe('client.message', function (dataArr) { console.log('Received client.message event!'); })
 
 ws.call('get.server.time', null, {
     onSuccess: function (dataArr, dataObj) {

--- a/src/wampy.js
+++ b/src/wampy.js
@@ -69,7 +69,8 @@ class Wampy {
                 subscriber: {
                     features: {
                         pattern_based_subscription: true,
-                        publication_trustlevels   : true
+                        publication_trustlevels   : true,
+                        publisher_identification  : true
                     }
                 },
                 caller    : {


### PR DESCRIPTION
The README file has confusing examples from 5.x syntax of subscribe().
This fixes that issue.