### PR TITLE
Fix "npm run lint" not working due to wrong Gruntfile extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
   "homepage": "https://github.com/KSDaemon/wampy.js#readme",
   "scripts": {
     "build": "node ./node_modules/.bin/grunt",
-    "lint": "node ./node_modules/eslint/bin/eslint src test Gruntfile.js",
-    "lint:fix": "node ./node_modules/eslint/bin/eslint --fix src test Gruntfile.js",
+    "lint": "node ./node_modules/eslint/bin/eslint src test Gruntfile.cjs",
+    "lint:fix": "node ./node_modules/eslint/bin/eslint --fix src test Gruntfile.cjs",
     "test": "npm run test:node && npm run test:browser",
     "test:node": "NODE_ENV=test c8 ./node_modules/mocha/bin/mocha --exit --require @babel/register -R spec",
     "test:node-no-crossbar": "NODE_ENV=test c8 ./node_modules/mocha/bin/mocha --exit --require @babel/register -R spec 'test/!(wampy-crossbar)-test.js'",

--- a/test/fake-ws-set-protocol.js
+++ b/test/fake-ws-set-protocol.js
@@ -5,7 +5,7 @@
  */
 
 import { JsonSerializer } from '../src/serializers/JsonSerializer.js';
-import {WAMP_MSG_SPEC} from "../src/constants.js";
+import { WAMP_MSG_SPEC } from '../src/constants.js';
 
 const TIMEOUT = 15,
 
@@ -78,7 +78,7 @@ WebSocket.prototype.send = function (data) {
                 }
             ])
         });
-    }, 10)
+    }, 10);
 };
 
 export { WebSocket, setProtocol };

--- a/test/wampy-serializer-handshake-test.js
+++ b/test/wampy-serializer-handshake-test.js
@@ -54,7 +54,7 @@ describe('Wampy.js Serializer Handshake', function () {
         wsSetProtocol('json');
 
         await wampy.connect();
-        const options = wampy.options()
+        const options = wampy.options();
         expect(options.serializer).to.be.instanceOf(JsonSerializer);
     });
 });


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### Description, Motivation and Context
- Fix wrong Gruntfile extension in package.json scripts;
- Fix fixable ESLint errors by running command "npm run lint:fix";

### What is the current behavior? 
When running "npm run lint", the following error message appears:
```
Oops! Something went wrong! :(

ESLint: 8.28.0

No files matching the pattern "Gruntfile.js" were found.
Please check for typing mistakes in the pattern.
```
### What is the new behavior?
Now, when running "npm run lint" the linter is successfully run.

### What kind of change does this PR introduce?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
