### PR TITLE
Refactor _isPlainObject

### DIFF
--- a/src/wampy.js
+++ b/src/wampy.js
@@ -422,43 +422,19 @@ class Wampy {
     }
 
     /**
-     * Check if value is object literal
-     * @param obj
+     * Check if input is an object literal
+     * @param input
      * @returns {boolean}
      * @private
      */
-    _isPlainObject (obj) {
-        if (!this._isObject(obj)) {
-            return false;
-        }
+    _isPlainObject (input) {
+        const constructor = input?.constructor;
+        const prototype = constructor?.prototype;
 
-        // If obj has modified constructor
-        const ctor = obj.constructor;
-        if (typeof ctor !== 'function') {
-            return false;
-        }
-
-        // If obj has modified prototype
-        const prot = ctor.prototype;
-        if (this._isObject(prot) === false) {
-            return false;
-        }
-
-        // If constructor does not have an Object-specific method
-        return Object.hasOwnProperty.call(prot, 'isPrototypeOf') !== false;
-    }
-
-    /**
-     * Check if value is an object
-     * @param obj
-     * @returns {boolean}
-     * @private
-     */
-    _isObject (obj) {
-        return obj !== null
-            && typeof obj === 'object'
-            && Array.isArray(obj) === false
-            && Object.prototype.toString.call(obj) === '[object Object]';
+        return Object.prototype.toString.call(input) === '[object Object]'      // checks for primitives, null, Arrays, DOM, etc.
+            && typeof constructor === 'function'                                // checks for modified constructors
+            && Object.hasOwn(prototype, 'isPrototypeOf')                        // checks for missing object-specific property
+            && Object.prototype.toString.call(prototype) === '[object Object]'; // checks for modified prototypes
     }
 
     /**

--- a/src/wampy.js
+++ b/src/wampy.js
@@ -431,10 +431,10 @@ class Wampy {
         const constructor = input?.constructor;
         const prototype = constructor?.prototype;
 
-        return Object.prototype.toString.call(input) === '[object Object]'      // checks for primitives, null, Arrays, DOM, etc.
-            && typeof constructor === 'function'                                // checks for modified constructors
-            && Object.hasOwn(prototype, 'isPrototypeOf')                        // checks for missing object-specific property
-            && Object.prototype.toString.call(prototype) === '[object Object]'; // checks for modified prototypes
+        return Object.prototype.toString.call(input) === '[object Object]'     // checks for primitives, null, Arrays, DOM, etc.
+            && typeof constructor === 'function'                               // checks for modified constructors
+            && Object.prototype.toString.call(prototype) === '[object Object]' // checks for modified prototypes
+            && Object.hasOwnProperty.call(prototype, 'isPrototypeOf');         // checks for missing object-specific property
     }
 
     /**


### PR DESCRIPTION
### Description, Motivation and Context
- Join all conditions into a single expression with descriptive comments to the side of each check;
- Remove _isObject since the following expression: "Object.prototype.toString.call(input) === '[object Object]'" Already checks against primitives, null, DOM, Arrays and built-ins such as Math...

### What kind of change does this PR introduce?
- [x] Refactoring

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
