### PR TITLE
Use Array.isArray() instead of internal "_isArray" function

### DIFF
--- a/src/wampy.js
+++ b/src/wampy.js
@@ -591,16 +591,13 @@ class Wampy {
         } else if (this._isPlainObject(payload)) {
             // It's a wampy unified form of payload passing
             if (payload.argsList || payload.argsDict) {
+                const isArgsListInvalid = payload.argsList && !Array.isArray(payload.argsList);
+                const isArgsDictInvalid = payload.argsDict && !this._isPlainObject(payload.argsDict);
 
-                if (payload.argsList && !Array.isArray(payload.argsList)) {
+                if (isArgsListInvalid || isArgsDictInvalid) {
+                    const invalidParameter = isArgsListInvalid ? payload.argsList : payload.argsDict;
                     err = true;
-                    this._fillOpStatusByError(new Errors.InvalidParamError(payload.argsList));
-                    return { err, payloadItems };
-                }
-
-                if (payload.argsDict && !this._isPlainObject(payload.argsDict)) {
-                    err = true;
-                    this._fillOpStatusByError(new Errors.InvalidParamError(payload.argsDict));
+                    this._fillOpStatusByError(new Errors.InvalidParamError(invalidParameter));
                     return { err, payloadItems };
                 }
 

--- a/src/wampy.js
+++ b/src/wampy.js
@@ -412,16 +412,6 @@ class Wampy {
     }
 
     /**
-     * Check if value is array
-     * @param obj
-     * @returns {boolean}
-     * @private
-     */
-    _isArray (obj) {
-        return (!!obj) && (Array.isArray(obj));
-    }
-
-    /**
      * Check if value is object literal
      * @param obj
      * @returns {boolean}
@@ -596,13 +586,13 @@ class Wampy {
     _packPPTPayload (payload, options) {
         let payloadItems = [], err = false, argsList, argsDict;
 
-        if (this._isArray(payload)) {
+        if (Array.isArray(payload)) {
             argsList = payload;
         } else if (this._isPlainObject(payload)) {
             // It's a wampy unified form of payload passing
             if (payload.argsList || payload.argsDict) {
 
-                if (payload.argsList && !this._isArray(payload.argsList)) {
+                if (payload.argsList && !Array.isArray(payload.argsList)) {
                     err = true;
                     this._fillOpStatusByError(new Errors.InvalidParamError(payload.argsList));
                     return { err, payloadItems };
@@ -1354,7 +1344,7 @@ class Wampy {
                                 const msg = [WAMP_MSG_SPEC.ERROR, WAMP_MSG_SPEC.INVOCATION,
                                     data[1], details || {}, error || 'wamp.error.invocation_exception'];
 
-                                if (argsList && self._isArray(argsList)) {
+                                if (argsList && Array.isArray(argsList)) {
                                     msg.push(argsList);
                                 }
 
@@ -1638,7 +1628,7 @@ class Wampy {
         if (this._options.realm) {
 
             const authOpts = (this._options.authid ? 1 : 0) +
-                ((this._isArray(this._options.authmethods) && this._options.authmethods.length) ? 1 : 0) +
+                ((Array.isArray(this._options.authmethods) && this._options.authmethods.length) ? 1 : 0) +
                 (typeof this._options.onChallenge === 'function' ||
                  Object.keys(this._options.authPlugins).length ? 1 : 0);
 
@@ -1883,7 +1873,7 @@ class Wampy {
         const options = { acknowledge: true }, callbacks = getNewPromise(),
             _optionsConvertHelper = (option, sourceType) => {
                 if (advancedOptions[option]) {
-                    if (this._isArray(advancedOptions[option]) && advancedOptions[option].length) {
+                    if (Array.isArray(advancedOptions[option]) && advancedOptions[option].length) {
                         options[option] = advancedOptions[option];
                     } else if (typeof advancedOptions[option] === sourceType) {
                         options[option] = [advancedOptions[option]];


### PR DESCRIPTION
### Description, Motivation and Context
- Internal _isArray function had a useless Boolean conversion (!!obj) that was always true because all Arrays (even an empty one) evaluate to Truthy.

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactoring

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
