### PR TITLE
Move session validation code to '_wsOnMessage'

### DIFF
--- a/src/wampy.js
+++ b/src/wampy.js
@@ -907,10 +907,10 @@ class Wampy {
             return this._hardClose(errorURI, `Received non-compliant WAMP message: "${messageType}"`);
         }
 
-        const needEmptySession = [WAMP_MSG_SPEC.WELCOME, WAMP_MSG_SPEC.CHALLENGE].includes(messageType);
-        const needValidSession = !needEmptySession && messageType !== WAMP_MSG_SPEC.ABORT;
+        const needNoSession = [WAMP_MSG_SPEC.WELCOME, WAMP_MSG_SPEC.CHALLENGE].includes(messageType);
+        const needValidSession = !needNoSession && messageType !== WAMP_MSG_SPEC.ABORT;
 
-        if (needEmptySession && this._cache.sessionId) {
+        if (needNoSession && this._cache.sessionId) {
             return this._hardClose(errorURI, `Received message "${messageType}" after session was established`);
         }
 


### PR DESCRIPTION


### Description, Motivation and Context
- Before, each message handler had its own session validation block. 
- Now, session validation is done inside function '_wsOnMessage' right before calling the specific handler, thus removing duplicate code.

### What kind of change does this PR introduce?
- [x] Refactoring (no new functionality, only code improvements)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
