### PR TITLE
Add .getOptions() and .setOptions()

### DIFF
--- a/Migrating.md
+++ b/Migrating.md
@@ -1,6 +1,12 @@
 Migrating from previous versions
 ================================
 
+Migrating from 7.x to 8.x versions
+==================================
+
+The `.options()` method has been marked as deprecated. We are still keeping backwards
+compatibility, but we recommend to switch to `.getOptions()` and `.setOptions()` instead.
+
 Migrating from 6.x to 7.x versions
 ==================================
 

--- a/Migrating.md
+++ b/Migrating.md
@@ -1,12 +1,6 @@
 Migrating from previous versions
 ================================
 
-Migrating from 7.x to 8.x versions
-==================================
-
-The `.options()` method has been marked as deprecated. We are still keeping backwards
-compatibility, but we recommend to switch to `.getOptions()` and `.setOptions()` instead.
-
 Migrating from 6.x to 7.x versions
 ==================================
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ wampy = new Wampy({
 
 ### options([opts])
 
-⚠️ .options() method is now deprecated, so this is here only for documentation purposes.
+.options() method is now deprecated, so this is here only for documentation purposes. Please use `getOptions()/setOptions()` instead.
 
 .options() can be called in two forms:
 -- without parameters it will behave the same as new method [getOptions()](#getoptions)

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ Javascript implementation (for browser and node.js)
   - [Migrating or Updating versions](#migrating-or-updating-versions)
   - [API](#api)
     - [Constructor(\[url\[, options\]\])](#constructorurl-options)
+    - [options(\[opts\])](#optionsopts)
     - [getOptions()](#getoptions)
-    - [setOptions(\[options\])](#setoptionsoptions)
+    - [setOptions(\[newOptions\])](#setoptionsnewoptions)
     - [getOpStatus()](#getopstatus)
     - [getSessionId()](#getsessionid)
     - [connect(\[url\])](#connecturl)
@@ -233,6 +234,27 @@ wampy = new Wampy({
 
 [Back to Table of Contents](#table-of-contents)
 
+### options([opts])
+
+⚠️ .options() method is now deprecated, so this is here only for documentation purposes.
+
+.options() can be called in two forms:
+-- without parameters it will behave the same as new method [getOptions()](#getoptions)
+-- with one parameter as a hash-table it will behave the same as new method [setOptions()](#setoptionsnewoptions)
+
+```javascript
+wampy.options(); // same as wampy.getOptions
+
+wampy.options({ // same as wampy.setOptions
+    authPlugins: {
+        ticket: ((userPassword) => (() => userPassword ))(),
+        wampcra: wampyCra.sign(secret),
+        cryptosign: wampyCryptosign.sign(privateKey)
+    },
+    authMode: 'auto'
+});
+```
+
 ### getOptions()
 
 Returns Wampy configuration options. See setOptions() down below for the full list of available options.
@@ -241,9 +263,9 @@ Returns Wampy configuration options. See setOptions() down below for the full li
 wampy.getOptions();
 ```
 
-### setOptions([options])
+### setOptions([newOptions])
 
-Receives an options object as a parameter, where each property is a new option to be set and returns a Wampy instance.
+Receives a newOptions object as a parameter, where each property is a new option to be set and returns a Wampy instance.
 
 Options attributes description:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Javascript implementation (for browser and node.js)
   - [Migrating or Updating versions](#migrating-or-updating-versions)
   - [API](#api)
     - [Constructor(\[url\[, options\]\])](#constructorurl-options)
-    - [options(\[opts\])](#optionsopts)
+    - [getOptions()](#getoptions)
+    - [setOptions(\[options\])](#setoptionsoptions)
     - [getOpStatus()](#getopstatus)
     - [getSessionId()](#getsessionid)
     - [connect(\[url\])](#connecturl)
@@ -232,12 +233,17 @@ wampy = new Wampy({
 
 [Back to Table of Contents](#table-of-contents)
 
-### options([opts])
+### getOptions()
 
-.options() method can be called in two forms:
+Returns Wampy configuration options. See setOptions() down below for the full list of available options.
 
-- without parameters it will return the current options
-- with one parameter as a hash-table it will set new options and return a Wampy instance back
+```javascript
+wampy.getOptions();
+```
+
+### setOptions([options])
+
+Receives an options object as a parameter, where each property is a new option to be set and returns a Wampy instance.
 
 Options attributes description:
 
@@ -263,7 +269,7 @@ You can provide your own sign functions or use existing helpers. Functions may b
 const wampyCra = require('wampy-cra');
 const wampyCryptosign = require('wampy-cryptosign');
 
-wampy.options({
+wampy.setOptions({
     authPlugins: {
         // No need to process challenge data in ticket flow, as it is empty
         ticket: ((userPassword) => (() => userPassword ))(),
@@ -300,9 +306,7 @@ instead of default `json`.
 using in Payload Passthru Mode. Allows to specify a few serializers and use them on per message/call basis.
 
 ```javascript
-wampy.options();
-
-wampy.options({
+wampy.setOptions({
     reconnectInterval: 1000,
     maxRetries: 999,
     onClose: () => { console.log('See you next time!'); },

--- a/src/wampy.js
+++ b/src/wampy.js
@@ -1510,19 +1510,45 @@ class Wampy {
      *************************************************************************/
 
     /**
+     * DEPRECATED
+     *
      * Get or set Wampy options
      *
      * To get options - call without parameters
      * To set options - pass hash-table with options values
      *
-     * @param {object} [opts]
+     * @param {object} [newOptions]
      * @returns {*}
      */
-    options (opts) {
-        if (typeof (opts) === 'undefined') {
+    options (newOptions) {
+        console.warn('Wampy.options() is deprecated, please use Wampy.getOptions() or Wampy.setOptions() instead');
+
+        if (typeof (newOptions) === 'undefined') {
             return this._options;
-        } else if (this._isPlainObject(opts)) {
-            this._options = { ...this._options, ...opts };
+        } else if (this._isPlainObject(newOptions)) {
+            this._options = { ...this._options, ...newOptions };
+            return this;
+        }
+    }
+
+    /**
+     * Wampy options getter
+     *
+     * @returns {object}
+     */
+    getOptions () {
+        return this._options;
+    }
+
+    /**
+     * Wampy options setter
+     *
+     * @param {object} newOptions
+     * @returns {*}
+     */
+    setOptions (newOptions) {
+        if (this._isPlainObject(newOptions)) {
+            this._options = { ...this._options, ...newOptions };
             return this;
         }
     }

--- a/src/wampy.js
+++ b/src/wampy.js
@@ -1499,7 +1499,7 @@ class Wampy {
      *************************************************************************/
 
     /**
-     * DEPRECATED
+     * @deprecated since version 7.0.1
      *
      * Get or set Wampy options
      *

--- a/test/wampy-common-test.js
+++ b/test/wampy-common-test.js
@@ -170,7 +170,7 @@ serializers.forEach(function (item) {
                     serializer: new serializer()
                 };
                 let wampy = new Wampy(setoptions);
-                let options = wampy.options();
+                let options = wampy.getOptions();
 
                 expect(options.autoReconnect).to.be.true;
                 expect(options.reconnectInterval).to.be.equal(10000);
@@ -189,7 +189,7 @@ serializers.forEach(function (item) {
 
                 wampy = new Wampy(routerUrl, setoptions);
                 await wampy.connect();
-                options = wampy.options();
+                options = wampy.getOptions();
 
                 expect(options.autoReconnect).to.be.true;
                 expect(options.reconnectInterval).to.be.equal(10000);
@@ -543,7 +543,7 @@ serializers.forEach(function (item) {
                         customFiled2: 'string',
                         customFiled3: [1, 2, 3, 4, 5]
                     },
-                    options = wampy.options({
+                    options = wampy.setOptions({
                         realm             : 'AppRealm',
                         autoReconnect     : true,
                         reconnectInterval : 1000,
@@ -557,7 +557,7 @@ serializers.forEach(function (item) {
                         onReconnectSuccess: function () {},
                         authid            : 'userid',
                         authmethods       : ['wampcra'],
-                    }).options();
+                    }).getOptions();
 
                 expect(options.autoReconnect).to.be.true;
                 expect(options.reconnectInterval).to.be.equal(1000);
@@ -587,25 +587,25 @@ serializers.forEach(function (item) {
             });
 
             it('allows to disconnect from connected server', function (done) {
-                wampy.options({ onConnect: null, onClose: done })
+                wampy.setOptions({ onConnect: null, onClose: done })
                     .disconnect();
             });
 
             it('disallows to connect without specifying all of [onChallenge, authid, authmethods]', async function () {
                 try {
-                    wampy.options({ authid: 'userid', authmethods: ['wampcra'], onChallenge: null }).connect();
+                    wampy.setOptions({ authid: 'userid', authmethods: ['wampcra'], onChallenge: null }).connect();
                 } catch (e) {
                     expect(e).to.be.instanceOf(Errors.NoCRACallbackOrIdError);
                 }
 
                 try {
-                    wampy.options({ authid: null, authmethods: ['wampcra'], onChallenge: null }).connect();
+                    wampy.setOptions({ authid: null, authmethods: ['wampcra'], onChallenge: null }).connect();
                 } catch (e) {
                     expect(e).to.be.instanceOf(Errors.NoCRACallbackOrIdError);
                 }
 
                 try {
-                    wampy.options({
+                    wampy.setOptions({
                         authid: null, onChallenge: function () {
                         }
                     }).connect();
@@ -614,7 +614,7 @@ serializers.forEach(function (item) {
                 }
 
                 try {
-                    wampy.options({
+                    wampy.setOptions({
                         authid: null, authmethods: [], onChallenge: function () {
                         }
                     }).connect();
@@ -623,7 +623,7 @@ serializers.forEach(function (item) {
                 }
 
                 try {
-                    wampy.options({
+                    wampy.setOptions({
                         authid: 'userid', authmethods: 'string', onChallenge: function () {
                         }
                     }).connect();
@@ -631,11 +631,11 @@ serializers.forEach(function (item) {
                     expect(e).to.be.instanceOf(Errors.NoCRACallbackOrIdError);
                 }
 
-                wampy.options({ authid: null, onChallenge: null });
+                wampy.setOptions({ authid: null, onChallenge: null });
             });
 
             it('calls onError handler if authentication using CRA fails', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     authid: 'user1',
                     authmethods: ['wampcra'],
                     onChallenge: function (method, info) {
@@ -651,7 +651,7 @@ serializers.forEach(function (item) {
             });
 
             it('calls onError handler if server requests authentication, but no credentials were provided', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     onError: function (e) {
                         done();
                     },
@@ -665,14 +665,14 @@ serializers.forEach(function (item) {
             });
 
             it('automatically sends goodbye message on server initiated disconnect', function (done) {
-                wampy.options({ onConnect: null, onClose: done })
+                wampy.setOptions({ onConnect: null, onClose: done })
                     .connect();
             });
 
             it('allows to disconnect while connecting to server', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     onClose: function () {
-                        wampy.options({ onClose: null });
+                        wampy.setOptions({ onClose: null });
                         done();
                     }
                 }).connect();
@@ -692,10 +692,10 @@ serializers.forEach(function (item) {
             });
 
             it('allows to abort WebSocketModule.WebSocket/WAMP session establishment', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     onClose: function () {
                         setTimeout(function () {
-                            wampy.options({ onClose: done })
+                            wampy.setOptions({ onClose: done })
                                 .connect(anotherRouterUrl);
 
                             setTimeout(function () {
@@ -710,14 +710,14 @@ serializers.forEach(function (item) {
             it('auto-reconnects to WAMP server on network errors', function (done) {
                 let onReconnect = false;
 
-                wampy.options({
+                wampy.setOptions({
                     autoReconnect     : true,
                     reconnectInterval : 10,
                     onClose           : null,
                     onError           : null,
                     onReconnect       : function () {
                         onReconnect = true;
-                        wampy.options({ onReconnect: null });
+                        wampy.setOptions({ onReconnect: null });
                     },
                     onReconnectSuccess: null
                 }).connect().then(async () => {
@@ -773,7 +773,7 @@ serializers.forEach(function (item) {
             });
 
             it('calls error handler if server sends abort message', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     onClose: null,
                     onError: function (e) {
                         done();
@@ -787,7 +787,7 @@ serializers.forEach(function (item) {
         describe('PubSub module', function () {
 
             before(async function () {
-                await wampy.options({
+                await wampy.setOptions({
                     uriValidation: 'strict',
                     onClose      : null,
                     onReconnect  : null,
@@ -820,9 +820,9 @@ serializers.forEach(function (item) {
             });
 
             it('disallows to subscribe to topic with invalid URI', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     onClose: function () {
-                        wampy.options({ onClose: null });
+                        wampy.setOptions({ onClose: null });
                         setTimeout(async function () {
                             await wampy.connect();
 
@@ -864,7 +864,7 @@ serializers.forEach(function (item) {
             });
 
             it('disallows to publish/subscribe to topic if uri validation mode is specified incorrectly', async function () {
-                wampy.options({ uriValidation: 'invalid' });
+                wampy.setOptions({ uriValidation: 'invalid' });
                 try {
                     await wampy.subscribe('qwe.asd.zxc.', function (e) {});
                 } catch (e) {
@@ -888,7 +888,7 @@ serializers.forEach(function (item) {
                 } catch (e) {
                     expect(e).to.be.instanceOf(Errors.UriError);
                 }
-                wampy.options({ uriValidation: 'strict' });
+                wampy.setOptions({ uriValidation: 'strict' });
             });
 
             it('checks for valid advanced options during subscribing to topic', async function () {
@@ -949,10 +949,10 @@ serializers.forEach(function (item) {
             });
 
             it('allows to subscribe to topic lax URI (with loose check option)', async function () {
-                wampy.options({ uriValidation: 'loose' });
+                wampy.setOptions({ uriValidation: 'loose' });
 
                 await wampy.subscribe('qwe//adsa//dfff', function (e) {});
-                wampy.options({ uriValidation: 'strict' });
+                wampy.setOptions({ uriValidation: 'strict' });
             });
 
 
@@ -1397,7 +1397,7 @@ serializers.forEach(function (item) {
         describe('RPC module', function () {
 
             before(async function () {
-                await wampy.options({
+                await wampy.setOptions({
                     onReconnect  : null,
                     onError      : null
                 }).disconnect();
@@ -1437,7 +1437,7 @@ serializers.forEach(function (item) {
             });
 
             it('disallows to register RPC with invalid URI', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     onClose: function () {
                         setTimeout(async function () {
                             await wampy.connect();
@@ -1480,7 +1480,7 @@ serializers.forEach(function (item) {
             });
 
             it('disallows to call/register an RPC if uri validation mode is specified incorrectly', async function () {
-                wampy.options({ uriValidation: 'invalid' });
+                wampy.setOptions({ uriValidation: 'invalid' });
                 try {
                     await wampy.register('qwe.asd.zxc.', function (e) {});
                 } catch (e) {
@@ -1504,7 +1504,7 @@ serializers.forEach(function (item) {
                 } catch (e) {
                     expect(e).to.be.instanceOf(Errors.UriError);
                 }
-                wampy.options({ uriValidation: 'strict' });
+                wampy.setOptions({ uriValidation: 'strict' });
             });
 
             it('checks for valid advanced options during RPC registration', function () {
@@ -1549,7 +1549,7 @@ serializers.forEach(function (item) {
             });
 
             it('disallows to cancel RPC invocation if dealer does not support call cancelling', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     onClose: function () {
                         setTimeout(async function () {
                             await wampy.connect();
@@ -1568,7 +1568,7 @@ serializers.forEach(function (item) {
             });
 
             it('allows to register RPC', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     onClose: function () {
                         setTimeout(async function () {
                             await wampy.connect();
@@ -2223,7 +2223,7 @@ serializers.forEach(function (item) {
             }
 
             before(async function () {
-                await wampy.options({
+                await wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer(),
                         msgpack: new MsgpackSerializer(),
@@ -2878,7 +2878,7 @@ serializers.forEach(function (item) {
             });
 
             it('doesn\'t fail if event in ppt mode was received, while ppt serializer is not supported', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer(),
                     }
@@ -2889,7 +2889,7 @@ serializers.forEach(function (item) {
             });
 
             it('doesn\'t fail if event in ppt mode was received, while payload decode fails', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer(),
                         cbor: new CborSerializer()
@@ -2901,7 +2901,7 @@ serializers.forEach(function (item) {
             });
 
             it('calls error handler if RPC Result is in ppt mode, while ppt serializer is not supported', async function () {
-                await wampy.options({
+                await wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer()
                     }
@@ -2916,7 +2916,7 @@ serializers.forEach(function (item) {
             });
 
             it('calls error handler if RPC Result is in ppt mode, while ppt decoding fails', async function () {
-                await wampy.options({
+                await wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer(),
                         cbor: new CborSerializer()
@@ -2932,7 +2932,7 @@ serializers.forEach(function (item) {
             });
 
             it('calls error handler if RPC Invocation is in ppt mode, while ppt serializer is not supported', async function () {
-                await wampy.options({
+                await wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer()
                     }
@@ -2947,7 +2947,7 @@ serializers.forEach(function (item) {
             });
 
             it('calls error handler if RPC Invocation is in ppt mode, while ppt decoding fails', async function () {
-                await wampy.options({
+                await wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer(),
                         cbor: new CborSerializer()
@@ -2963,7 +2963,7 @@ serializers.forEach(function (item) {
             });
 
             it('calls error handler if RPC YIELD is sent with wrong ppt_scheme', async function () {
-                await wampy.options({
+                await wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer(),
                         cbor: new CborSerializer(),
@@ -2985,7 +2985,7 @@ serializers.forEach(function (item) {
             });
 
             it('calls error handler if RPC YIELD results PPT packing fails', async function () {
-                await wampy.options({
+                await wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer(),
                         cbor: new CborSerializer(),
@@ -3012,7 +3012,7 @@ serializers.forEach(function (item) {
             });
 
             it('calls error handler if RPC YIELD results PPT serializer is not supported', async function () {
-                await wampy.options({
+                await wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer(),
                         cbor: new CborSerializer()
@@ -3033,7 +3033,7 @@ serializers.forEach(function (item) {
             });
 
             it('allows to receive RPC Invocation in ppt mode', async function () {
-                await wampy.options({
+                await wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer(),
                         msgpack: new MsgpackSerializer(),
@@ -3050,7 +3050,7 @@ serializers.forEach(function (item) {
             });
 
             it('doesn\'t fail if event in ppt mode was received, while broker didn\'t announce it', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer(),
                         msgpack: new MsgpackSerializer(),
@@ -3069,7 +3069,7 @@ serializers.forEach(function (item) {
             });
 
             it('calls error handler if RPC Result in ppt mode was received, while dealer didn\'t announce it', async function () {
-                await wampy.options({
+                await wampy.setOptions({
                     payloadSerializers: {
                         json: new JsonSerializer(),
                         msgpack: new MsgpackSerializer(),
@@ -3087,7 +3087,7 @@ serializers.forEach(function (item) {
 
             it('aborts connection when receiving invocation in ppt mode, while dealer didn\'t announce it', function (done) {
                 // This case should not happen at all, but for safety
-                wampy.options({
+                wampy.setOptions({
                     autoReconnect: false,
                     payloadSerializers: {
                         json: new JsonSerializer(),
@@ -3104,7 +3104,7 @@ serializers.forEach(function (item) {
             });
 
             it('aborts connection if RPC YIELD is in ppt mode, while dealer didn\'t announce it', function (done) {
-                wampy.options({
+                wampy.setOptions({
                     autoReconnect: false,
                     payloadSerializers: {
                         json: new JsonSerializer(),

--- a/test/wampy-serializer-handshake-test.js
+++ b/test/wampy-serializer-handshake-test.js
@@ -44,6 +44,6 @@ describe('Wampy.js Serializer Handshake', function () {
         wsSetProtocol('json');
         await wampy.connect();
 
-        expect(wampy.options().serializer).to.be.instanceOf(JsonSerializer);
+        expect(wampy.getOptions().serializer).to.be.instanceOf(JsonSerializer);
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description, Motivation and Context
Fixes #215.
To conform to the [Single Responsibility Principle](https://en.wikipedia.org/wiki/Single-responsibility_principle), `.options()` has now been marked as deprecated and two new methods have been added: `.getOptions()` and `.setOptions()`. 

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no new functionality, only code improvements)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [ ] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
