### PR TITLE
Replace [a-zA-Z0-9_] with \w

### DIFF
--- a/src/wampy.js
+++ b/src/wampy.js
@@ -530,19 +530,16 @@ class Wampy {
     _validateURI (uri, isPatternBased, isWampAllowed) {
         const isStrictValidation = this._options.uriValidation === 'strict';
         const isLooseValidation = this._options.uriValidation === 'loose';
+        const isValidationTypeUnknown = !isStrictValidation && !isLooseValidation;
+
+        if (isValidationTypeUnknown || (uri.startsWith('wamp.') && !isWampAllowed)) {
+            return false;
+        }
+
         let reBase, rePattern;
-
-        if (!isStrictValidation && !isLooseValidation) {
-            return false;
-        }
-
-        if (uri.startsWith('wamp.') && !isWampAllowed) {
-            return false;
-        }
-
         if (isStrictValidation) {
-            reBase = /^([0-9a-zA-Z_]+\.)*([0-9a-zA-Z_]+)$/;
-            rePattern = /^([0-9a-zA-Z_]+\.{1,2})*([0-9a-zA-Z_]+)$/;
+            reBase = /^(\w+\.)*(\w+)$/;
+            rePattern = /^(\w+\.{1,2})*(\w+)$/;
         } else if (isLooseValidation) {
             reBase = /^([^\s.#]+\.)*([^\s.#]+)$/;
             rePattern = /^([^\s.#]+\.{1,2})*([^\s.#]+)$/;


### PR DESCRIPTION
### Description, Motivation and Context
The \w regex metacharacter has full browser and Node support and already matches characters included in a-z, A-Z, 0-9, and _ (underscore).

Also, this change joins `_validateURI` "false" exit statements into one statement

### What kind of change does this PR introduce?
- [x] Refactoring (no new functionality, only code improvements)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
