### PR TITLE
Refactor utils.getWebSocket to improve test coverage by +0.2%

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -29,22 +29,24 @@ export function getServerUrlForBrowser (url) {
     return `${scheme}${url}`;
 }
 
-export function getWebSocket (options = {}) {
-    const { url, protocols, ws, headers, requestOptions, isBrowserMock } = options;
-    const parsedUrl = (isNode && !isBrowserMock) ? getServerUrlForNode(url) : getServerUrlForBrowser(url);
+export function getWebSocket (wampy = {}) {
+    const { _url, _protocols, _options, isBrowserMock } = wampy;
+    const parsedUrl = (isNode && !isBrowserMock) ? getServerUrlForNode(_url) : getServerUrlForBrowser(_url);
 
     if (!parsedUrl) {
         return null;
     }
 
-    if (ws) {   // User provided webSocket class
-        return new ws(parsedUrl, protocols, null, headers, requestOptions);
+    if (_options?.ws) { // User provided webSocket class
+        const { ws, additionalHeaders, wsRequestOptions } = _options;
+
+        return new ws(parsedUrl, _protocols, null, additionalHeaders, wsRequestOptions);
     } else if (isNode && !isBrowserMock) { // we're in node, but no webSocket class was provided
         return null;
     } else if (window?.WebSocket) { // Chrome, MSIE, newer Firefox
-        return new window.WebSocket(parsedUrl, protocols);
+        return new window.WebSocket(parsedUrl, _protocols);
     } else if (window?.MozWebSocket) { // older versions of Firefox
-        return new window.MozWebSocket(parsedUrl, protocols);
+        return new window.MozWebSocket(parsedUrl, _protocols);
     }
 
     return null;

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,12 +29,12 @@ function getServerUrlForBrowser (url) {
     return `${scheme}${url}`;
 }
 
-/** Get a WebSocket object from the browsers's "window" global variable
+/** Get a WebSocket object from the browsers's window global variable
  *
  * @param {string} parsedUrl The server URL
  * @param {string[]} protocols The WebSocket protocols
  *
- * @returns {Object} a WebSocket Object, or null if none is found
+ * @returns {Object} A WebSocket Object, or null if none is found
  */
 function getWebSocketFromWindowObject (parsedUrl, protocols) {
     if (window?.WebSocket) { // Chrome, MSIE, newer Firefox
@@ -48,18 +48,19 @@ function getWebSocketFromWindowObject (parsedUrl, protocols) {
 
 /** Get a WebSocket object according to the user's current environment
  *
- * @param {Object} wampy an optional wampy instance
- * @param {string} wampy._url The WebSocket URL
- * @param {Object} wampy._options An options hash-table.
- * @param {string[]} wampy._protocols The WebSocket protocols
- * @param {boolean} wampy.isBrowserMock a flag indicating if the
- * function is being called from a simulated browser environment
- * (such as NodeJS tests that use jsdom).
+ * @param {Object} configObject A configuration object containing multiple properties
+ * @param {string} configObject.url The WebSocket URL
+ * @param {string[]} configObject.protocols The WebSocket protocols
+ * @param {Object} configObject.options An options hash-table
+ * @param {WebSocket} configObject.options.ws A user-provided WebSocket class
+ * @param {Object} configObject.options.additionalHeaders User provided extra HTTP headers for Node.js
+ * @param {Object} configObject.options.wsRequestOptions User provided WS Client Config Options for Node.js
+ * @param {boolean} configObject.isBrowserMock A flag indicating if the environment is a simulated browser
+ * environment inside Node.js, such as jsdom.
  *
  * @returns {Object} a WebSocket Object, or null if none is found
  */
-export function getWebSocket (wampy = {}) {
-    const { url, protocols, options, isBrowserMock } = wampy;
+export function getWebSocket ({ url, protocols, options, isBrowserMock } = {}) {
     const { ws, additionalHeaders, wsRequestOptions } = options || {};
     const isActualNode = isNode && !isBrowserMock;
 
@@ -73,7 +74,7 @@ export function getWebSocket (wampy = {}) {
         return null;
     }
 
-    if (ws) { // User provided webSocket class
+    if (ws) {    // User-provided WebSocket class
         return new ws(parsedUrl, protocols, null, additionalHeaders, wsRequestOptions);
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,7 +29,18 @@ function getServerUrlForBrowser (url) {
     return `${scheme}${url}`;
 }
 
-
+/** Get a WebSocket object according to the user's current environment
+ *
+ * @param {Object} wampy an optional wampy instance
+ * @param {string} wampy._url The WebSocket URL
+ * @param {Object} wampy._options An options hash-table.
+ * @param {string[]} wampy._protocols The WebSocket protocols
+ * @param {boolean} wampy.isBrowserMock a flag indicating if the
+ * function is being called from a simulated browser environment
+ * (such as NodeJS tests that use jsdom).
+ *
+ * @returns {Object} a WebSocket Object, or null if none is found
+ */
 export function getWebSocket (wampy = {}) {
     const { _url, _options, _protocols, isBrowserMock } = wampy;
     const isActualNode = isNode && !isBrowserMock;

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,8 +29,9 @@ export function getServerUrlForBrowser (url) {
     return `${scheme}${url}`;
 }
 
-export function getWebSocket (url, protocols, ws, headers, requestOptions) {
-    const parsedUrl = isNode ? getServerUrlForNode(url) : getServerUrlForBrowser(url);
+export function getWebSocket (options = {}) {
+    const { url, protocols, ws, headers, requestOptions, isBrowserMock } = options;
+    const parsedUrl = (isNode && !isBrowserMock) ? getServerUrlForNode(url) : getServerUrlForBrowser(url);
 
     if (!parsedUrl) {
         return null;
@@ -38,11 +39,11 @@ export function getWebSocket (url, protocols, ws, headers, requestOptions) {
 
     if (ws) {   // User provided webSocket class
         return new ws(parsedUrl, protocols, null, headers, requestOptions);
-    } else if (isNode) {    // we're in node, but no webSocket provided
+    } else if (isNode && !isBrowserMock) { // we're in node, but no webSocket class was provided
         return null;
-    } else if ('WebSocket' in window) { // Chrome, MSIE, newer Firefox
+    } else if (window?.WebSocket) { // Chrome, MSIE, newer Firefox
         return new window.WebSocket(parsedUrl, protocols);
-    } else if ('MozWebSocket' in window) { // older versions of Firefox
+    } else if (window?.MozWebSocket) { // older versions of Firefox
         return new window.MozWebSocket(parsedUrl, protocols);
     }
 

--- a/src/wampy.js
+++ b/src/wampy.js
@@ -566,7 +566,7 @@ class Wampy {
         }
 
         const isPayloadAnObject = this._isPlainObject(payload);
-        const { argsList, argsDict } = payload || {};
+        const { argsList, argsDict } = payload;
         let args, kwargs;
 
         if (isPayloadAnObject && !argsList && !argsDict) {
@@ -616,11 +616,12 @@ class Wampy {
             }
         }
 
+        // TODO: implement End-to-End Encryption
         // wamp scheme means Payload End-to-End Encryption
         // @see https://wamp-proto.org/wamp_latest_ietf.html#name-payload-end-to-end-encrypti
-        if (options.ppt_scheme === 'wamp') {
-            // TODO: implement End-to-End Encryption
-        }
+        // if (options.ppt_scheme === 'wamp') {
+        //
+        // }
 
         payloadItems.push([binPayload]);
 
@@ -642,13 +643,12 @@ class Wampy {
             return { err: this._cache.opStatus.error };
         }
 
+        // TODO: implement End-to-End Encryption
         // wamp scheme means Payload End-to-End Encryption
         // @see https://wamp-proto.org/wamp_latest_ietf.html#name-payload-end-to-end-encrypti
-        if (options.ppt_scheme === 'wamp') {
-
-            // TODO: implement End-to-End Encryption
-
-        }
+        // if (options.ppt_scheme === 'wamp') {
+        //
+        // }
 
         if (options.ppt_serializer && options.ppt_serializer !== 'native') {
             const pptSerializer = this._options.payloadSerializers[options.ppt_serializer];
@@ -1079,7 +1079,7 @@ class Wampy {
             return;
         }
 
-        const { topic, advancedOptions, callbacks } = this._requests[requestId] || {};
+        const { topic, advancedOptions, callbacks } = this._requests[requestId];
         const subscription = {
             id: subscriptionId,
             topic,
@@ -1110,7 +1110,7 @@ class Wampy {
             return;
         }
 
-        const { topic, advancedOptions, callbacks } = this._requests[requestId] || {};
+        const { topic, advancedOptions, callbacks } = this._requests[requestId];
         const subscriptionKey = this._getSubscriptionKey(topic, advancedOptions);
         const subscriptionId = this._subscriptionsByKey.get(subscriptionKey).id;
         this._subscriptionsByKey.delete(subscriptionKey);
@@ -1351,8 +1351,8 @@ class Wampy {
         }
 
         const handleInvocationResult = (result) => {
-            const options = result?.options;
-            const { ppt_scheme, ppt_serializer, ppt_cipher, ppt_keyid } = options ?? {};
+            const options = result?.options || {};
+            const { ppt_scheme, ppt_serializer, ppt_cipher, ppt_keyid } = options;
 
             // Check and handle Payload PassThru Mode
             // @see https://wamp-proto.org/wamp_latest_ietf.html#name-payload-passthru-mode
@@ -1370,7 +1370,7 @@ class Wampy {
                 });
             }
 
-            const { err, payloadItems } = result ? this._packPPTPayload(result, options || {}) : {};
+            const { err, payloadItems } = result ? this._packPPTPayload(result, options) : {};
 
             if (err) {
                 return handleInvocationError({
@@ -1381,7 +1381,7 @@ class Wampy {
             }
 
             const messageOptions = {
-                ...(options || {}),
+                ...options,
                 ...(ppt_scheme ? { ppt_scheme } : {}),
                 ...(ppt_serializer ? { ppt_serializer } : {}),
                 ...(ppt_cipher ? { ppt_cipher } : {}),
@@ -1441,8 +1441,14 @@ class Wampy {
         }
 
         this._cache.reconnectingAttempts++;
-        this._ws = getWebSocket(this._url, this._protocols, this._options.ws,
-            this._options.additionalHeaders, this._options.wsRequestOptions);
+
+        this._ws = getWebSocket({
+            url: this._url,
+            protocols: this._protocols,
+            ws: this._options.ws,
+            headers: this._options.additionalHeaders,
+            requestOptions: this._options.wsRequestOptions,
+        });
         this._initWsCallbacks();
     }
 
@@ -1566,8 +1572,13 @@ class Wampy {
         }
 
         this._setWsProtocols();
-        this._ws = getWebSocket(this._url, this._protocols, this._options.ws,
-            this._options.additionalHeaders, this._options.wsRequestOptions);
+        this._ws = getWebSocket({
+            url: this._url,
+            protocols: this._protocols,
+            ws: this._options.ws,
+            headers: this._options.additionalHeaders,
+            requestOptions: this._options.wsRequestOptions,
+        });
 
         if (!this._ws) {
             const noWsOrUrlError = new Errors.NoWsOrUrlError();
@@ -1815,7 +1826,7 @@ class Wampy {
 
         options = {
             acknowledge: true,
-            ...(options || {}),
+            ...options,
             ...(ppt_scheme ? { ppt_scheme } : {}),
             ...(ppt_scheme ? { ppt_scheme } : {}),
             ...(ppt_serializer ? { ppt_serializer } : {}),

--- a/src/wampy.js
+++ b/src/wampy.js
@@ -1435,7 +1435,11 @@ class Wampy {
 
         this._cache.reconnectingAttempts++;
 
-        this._ws = getWebSocket(this);
+        this._ws = getWebSocket({
+            url: this._url,
+            protocols: this._protocols,
+            options: this._options,
+        });
         this._initWsCallbacks();
     }
 
@@ -1585,7 +1589,11 @@ class Wampy {
         }
 
         this._setWsProtocols();
-        this._ws = getWebSocket(this);
+        this._ws = getWebSocket({
+            url: this._url,
+            protocols: this._protocols,
+            options: this._options,
+        });
 
         if (!this._ws) {
             const noWsOrUrlError = new Errors.NoWsOrUrlError();

--- a/src/wampy.js
+++ b/src/wampy.js
@@ -566,7 +566,7 @@ class Wampy {
         }
 
         const isPayloadAnObject = this._isPlainObject(payload);
-        const { argsList, argsDict } = payload;
+        const { argsList, argsDict } = payload || {};
         let args, kwargs;
 
         if (isPayloadAnObject && !argsList && !argsDict) {
@@ -616,12 +616,11 @@ class Wampy {
             }
         }
 
-        // TODO: implement End-to-End Encryption
         // wamp scheme means Payload End-to-End Encryption
         // @see https://wamp-proto.org/wamp_latest_ietf.html#name-payload-end-to-end-encrypti
-        // if (options.ppt_scheme === 'wamp') {
-        //
-        // }
+        if (options.ppt_scheme === 'wamp') {
+            // TODO: implement End-to-End Encryption
+        }
 
         payloadItems.push([binPayload]);
 
@@ -643,12 +642,13 @@ class Wampy {
             return { err: this._cache.opStatus.error };
         }
 
-        // TODO: implement End-to-End Encryption
         // wamp scheme means Payload End-to-End Encryption
         // @see https://wamp-proto.org/wamp_latest_ietf.html#name-payload-end-to-end-encrypti
-        // if (options.ppt_scheme === 'wamp') {
-        //
-        // }
+        if (options.ppt_scheme === 'wamp') {
+
+            // TODO: implement End-to-End Encryption
+
+        }
 
         if (options.ppt_serializer && options.ppt_serializer !== 'native') {
             const pptSerializer = this._options.payloadSerializers[options.ppt_serializer];
@@ -1077,7 +1077,7 @@ class Wampy {
             return;
         }
 
-        const { topic, advancedOptions, callbacks } = this._requests[requestId];
+        const { topic, advancedOptions, callbacks } = this._requests[requestId] || {};
         const subscription = {
             id: subscriptionId,
             topic,
@@ -1108,7 +1108,7 @@ class Wampy {
             return;
         }
 
-        const { topic, advancedOptions, callbacks } = this._requests[requestId];
+        const { topic, advancedOptions, callbacks } = this._requests[requestId] || {};
         const subscriptionKey = this._getSubscriptionKey(topic, advancedOptions);
         const subscriptionId = this._subscriptionsByKey.get(subscriptionKey).id;
         this._subscriptionsByKey.delete(subscriptionKey);
@@ -1349,8 +1349,8 @@ class Wampy {
         }
 
         const handleInvocationResult = (result) => {
-            const options = result?.options || {};
-            const { ppt_scheme, ppt_serializer, ppt_cipher, ppt_keyid } = options;
+            const options = result?.options;
+            const { ppt_scheme, ppt_serializer, ppt_cipher, ppt_keyid } = options ?? {};
 
             // Check and handle Payload PassThru Mode
             // @see https://wamp-proto.org/wamp_latest_ietf.html#name-payload-passthru-mode
@@ -1368,7 +1368,7 @@ class Wampy {
                 });
             }
 
-            const { err, payloadItems } = result ? this._packPPTPayload(result, options) : {};
+            const { err, payloadItems } = result ? this._packPPTPayload(result, options || {}) : {};
 
             if (err) {
                 return handleInvocationError({
@@ -1379,7 +1379,7 @@ class Wampy {
             }
 
             const messageOptions = {
-                ...options,
+                ...(options || {}),
                 ...(ppt_scheme ? { ppt_scheme } : {}),
                 ...(ppt_serializer ? { ppt_serializer } : {}),
                 ...(ppt_cipher ? { ppt_cipher } : {}),
@@ -1434,11 +1434,10 @@ class Wampy {
         }
 
         this._cache.reconnectingAttempts++;
-
         this._ws = getWebSocket({
             url: this._url,
             protocols: this._protocols,
-            options: this._options,
+            options: this._options
         });
         this._initWsCallbacks();
     }
@@ -1592,7 +1591,7 @@ class Wampy {
         this._ws = getWebSocket({
             url: this._url,
             protocols: this._protocols,
-            options: this._options,
+            options: this._options
         });
 
         if (!this._ws) {
@@ -1841,7 +1840,7 @@ class Wampy {
 
         messageOptions = {
             acknowledge: true,
-            ...messageOptions,
+            ...(messageOptions || {}),
             ...(ppt_scheme ? { ppt_scheme } : {}),
             ...(ppt_scheme ? { ppt_scheme } : {}),
             ...(ppt_serializer ? { ppt_serializer } : {}),

--- a/src/wampy.js
+++ b/src/wampy.js
@@ -1442,13 +1442,7 @@ class Wampy {
 
         this._cache.reconnectingAttempts++;
 
-        this._ws = getWebSocket({
-            url: this._url,
-            protocols: this._protocols,
-            ws: this._options.ws,
-            headers: this._options.additionalHeaders,
-            requestOptions: this._options.wsRequestOptions,
-        });
+        this._ws = getWebSocket(this);
         this._initWsCallbacks();
     }
 
@@ -1572,13 +1566,7 @@ class Wampy {
         }
 
         this._setWsProtocols();
-        this._ws = getWebSocket({
-            url: this._url,
-            protocols: this._protocols,
-            ws: this._options.ws,
-            headers: this._options.additionalHeaders,
-            requestOptions: this._options.wsRequestOptions,
-        });
+        this._ws = getWebSocket(this);
 
         if (!this._ws) {
             const noWsOrUrlError = new Errors.NoWsOrUrlError();

--- a/test/wampy-utils-test.js
+++ b/test/wampy-utils-test.js
@@ -11,8 +11,8 @@ import { expect } from 'chai';
 import * as utils  from './../src/utils.js';
 let getWebSocket = utils.getWebSocket;
 
-function getPseudoBrowserWebSocket (options = {}) {
-    return utils.getWebSocket({ ...options, isBrowserMock: true });
+function getPseudoBrowserWebSocket (wampy = {}) {
+    return utils.getWebSocket({ ...wampy, isBrowserMock: true });
 }
 
 describe('Wampy.js Utils submodule', function () {
@@ -28,18 +28,18 @@ describe('Wampy.js Utils submodule', function () {
         });
 
         it('disallows to create websocket object without providing full qualified url', function () {
-            expect(getWebSocket({ url: '/just/path' })).to.be.null;
-            expect(getWebSocket({ url: 'example.com/' })).to.be.null;
-            expect(getWebSocket({ url: 'example.com:3128/just/path' })).to.be.null;
+            expect(getWebSocket({ _url: '/just/path' })).to.be.null;
+            expect(getWebSocket({ _url: 'example.com/' })).to.be.null;
+            expect(getWebSocket({ _url: 'example.com:3128/just/path' })).to.be.null;
         });
 
         it('disallows to create websocket instance without providing websocket class object', function () {
-            const optionsWithoutWsClass = { url:'ws://example.com/ws/path', protocols: ['wamp.2.json'] };
+            const optionsWithoutWsClass = { _url:'ws://example.com/ws/path', _protocols: ['wamp.2.json'] };
 
             expect(getWebSocket(optionsWithoutWsClass)).to.be.null;
 
             const wsClass = function (url) { this.name = 'UserWebSocket'; this.url = url; };
-            const optionsWithWsClass = { ...optionsWithoutWsClass, ws: wsClass };
+            const optionsWithWsClass = { ...optionsWithoutWsClass, _options: { ws: wsClass } };
 
             expect(getWebSocket(optionsWithWsClass)).to.be.instanceOf(wsClass);
         });
@@ -79,93 +79,93 @@ describe('Wampy.js Utils submodule', function () {
 
         it('allows to create websocket object with just path in url', function () {
             global.window.location = { port: '', hostname: 'localhost', protocol: 'http:' };
-            let ws = getWebSocket({ url: '/websocket/wamp' });
+            let ws = getWebSocket({ _url: '/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://localhost/websocket/wamp');
 
             global.window.location = { port: '8888', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket({ url:'/websocket/wamp' });
+            ws = getWebSocket({ _url:'/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://localhost:8888/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ url:'/websocket/wamp' });
+            ws = getWebSocket({ _url:'/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://localhost/websocket/wamp');
 
             global.window.location = { port: '1234', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ url:'/websocket/wamp' });
+            ws = getWebSocket({ _url:'/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://localhost:1234/websocket/wamp');
         });
 
         it('allows to create websocket object with domain+path url', function () {
             global.window.location = { port: '', hostname: 'localhost', protocol: 'http:' };
-            let ws = getWebSocket({ url:'example.com/websocket/wamp' });
+            let ws = getWebSocket({ _url:'example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '8888', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket({ url:'example.com/websocket/wamp' });
+            ws = getWebSocket({ _url:'example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ url:'example.com/websocket/wamp' });
+            ws = getWebSocket({ _url:'example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             global.window.location = { port: '1234', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ url:'example.com/websocket/wamp' });
+            ws = getWebSocket({ _url:'example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
         });
 
         it('allows to create websocket object with full qualified url', function () {
             global.window.location = { port: '', hostname: 'localhost', protocol: 'http:' };
-            let ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
+            let ws = getWebSocket({ _url:'ws://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '8888', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
+            ws = getWebSocket({ _url:'ws://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
+            ws = getWebSocket({ _url:'ws://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '1234', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
+            ws = getWebSocket({ _url:'ws://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
+            ws = getWebSocket({ _url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             global.window.location = { port: '8888', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
+            ws = getWebSocket({ _url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
+            ws = getWebSocket({ _url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             global.window.location = { port: '1234', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
+            ws = getWebSocket({ _url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             // Test for returning MozWebSocket in old firefoxes
             delete global.window.WebSocket;
             global.window.MozWebSocket = function (url) { this.name = 'MozWebSocket'; this.url = url; };
-            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
+            ws = getWebSocket({ _url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('MozWebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
             delete global.window.MozWebSocket;
@@ -174,7 +174,7 @@ describe('Wampy.js Utils submodule', function () {
 
         it('disallows to create websocket instance if WebSocket object is not available in window', function () {
             delete global.window.WebSocket;
-            expect(getWebSocket({ url:'ws://example.com/ws/path' })).to.be.null;
+            expect(getWebSocket({ _url:'ws://example.com/ws/path' })).to.be.null;
             global.window.WebSocket = function (url) { this.name = 'WebSocket'; this.url = url; };
         });
 
@@ -195,23 +195,23 @@ describe('Wampy.js Utils submodule', function () {
         });
 
         it('allows to create websocket object with just path in url', function () {
-            const ws = getWebSocket({ url:'/websocket/wamp' });
+            const ws = getWebSocket({ _url:'/websocket/wamp' });
 
             expect(ws.url).to.be.equal('ws://localhost:9876/websocket/wamp');
         });
 
         it('allows to create websocket object with domain+path url', function () {
-            const ws = getWebSocket({ url:'example.com/websocket/wamp' });
+            const ws = getWebSocket({ _url:'example.com/websocket/wamp' });
 
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
         });
 
         it('allows to create websocket object with full qualified url', function () {
-            let ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
+            let ws = getWebSocket({ _url:'ws://example.com/websocket/wamp' });
 
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
-            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
+            ws = getWebSocket({ _url:'wss://example.com/websocket/wamp' });
 
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
         });

--- a/test/wampy-utils-test.js
+++ b/test/wampy-utils-test.js
@@ -4,15 +4,14 @@
  * Date: 22.06.17
  */
 
-const isNode = typeof process === 'object' &&
-    Object.prototype.toString.call(process) === '[object process]';
-
 import { expect } from 'chai';
 import * as utils  from './../src/utils.js';
+
+const isNode = Object.prototype.toString.call(process) === '[object process]';
 let getWebSocket = utils.getWebSocket;
 
-function getPseudoBrowserWebSocket (wampy = {}) {
-    return utils.getWebSocket({ ...wampy, isBrowserMock: true });
+function getPseudoBrowserWebSocket (configObject = {}) {
+    return utils.getWebSocket({ ...configObject, isBrowserMock: true });
 }
 
 describe('Wampy.js Utils submodule', function () {
@@ -34,14 +33,14 @@ describe('Wampy.js Utils submodule', function () {
         });
 
         it('disallows to create websocket instance without providing websocket class object', function () {
-            const optionsWithoutWsClass = { url:'ws://example.com/ws/path', protocols: ['wamp.2.json'] };
+            const configWithoutWsClass = { url:'ws://example.com/ws/path', protocols: ['wamp.2.json'] };
 
-            expect(getWebSocket(optionsWithoutWsClass)).to.be.null;
+            expect(getWebSocket(configWithoutWsClass)).to.be.null;
 
             const wsClass = function (url) { this.name = 'UserWebSocket'; this.url = url; };
-            const optionsWithWsClass = { ...optionsWithoutWsClass, options: { ws: wsClass } };
+            const configWithWsClass = { ...configWithoutWsClass, options: { ws: wsClass } };
 
-            expect(getWebSocket(optionsWithWsClass)).to.be.instanceOf(wsClass);
+            expect(getWebSocket(configWithWsClass)).to.be.instanceOf(wsClass);
         });
     });
 

--- a/test/wampy-utils-test.js
+++ b/test/wampy-utils-test.js
@@ -28,18 +28,18 @@ describe('Wampy.js Utils submodule', function () {
         });
 
         it('disallows to create websocket object without providing full qualified url', function () {
-            expect(getWebSocket({ _url: '/just/path' })).to.be.null;
-            expect(getWebSocket({ _url: 'example.com/' })).to.be.null;
-            expect(getWebSocket({ _url: 'example.com:3128/just/path' })).to.be.null;
+            expect(getWebSocket({ url: '/just/path' })).to.be.null;
+            expect(getWebSocket({ url: 'example.com/' })).to.be.null;
+            expect(getWebSocket({ url: 'example.com:3128/just/path' })).to.be.null;
         });
 
         it('disallows to create websocket instance without providing websocket class object', function () {
-            const optionsWithoutWsClass = { _url:'ws://example.com/ws/path', _protocols: ['wamp.2.json'] };
+            const optionsWithoutWsClass = { url:'ws://example.com/ws/path', protocols: ['wamp.2.json'] };
 
             expect(getWebSocket(optionsWithoutWsClass)).to.be.null;
 
             const wsClass = function (url) { this.name = 'UserWebSocket'; this.url = url; };
-            const optionsWithWsClass = { ...optionsWithoutWsClass, _options: { ws: wsClass } };
+            const optionsWithWsClass = { ...optionsWithoutWsClass, options: { ws: wsClass } };
 
             expect(getWebSocket(optionsWithWsClass)).to.be.instanceOf(wsClass);
         });
@@ -79,93 +79,93 @@ describe('Wampy.js Utils submodule', function () {
 
         it('allows to create websocket object with just path in url', function () {
             global.window.location = { port: '', hostname: 'localhost', protocol: 'http:' };
-            let ws = getWebSocket({ _url: '/websocket/wamp' });
+            let ws = getWebSocket({ url: '/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://localhost/websocket/wamp');
 
             global.window.location = { port: '8888', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket({ _url:'/websocket/wamp' });
+            ws = getWebSocket({ url:'/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://localhost:8888/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ _url:'/websocket/wamp' });
+            ws = getWebSocket({ url:'/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://localhost/websocket/wamp');
 
             global.window.location = { port: '1234', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ _url:'/websocket/wamp' });
+            ws = getWebSocket({ url:'/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://localhost:1234/websocket/wamp');
         });
 
         it('allows to create websocket object with domain+path url', function () {
             global.window.location = { port: '', hostname: 'localhost', protocol: 'http:' };
-            let ws = getWebSocket({ _url:'example.com/websocket/wamp' });
+            let ws = getWebSocket({ url:'example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '8888', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket({ _url:'example.com/websocket/wamp' });
+            ws = getWebSocket({ url:'example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ _url:'example.com/websocket/wamp' });
+            ws = getWebSocket({ url:'example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             global.window.location = { port: '1234', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ _url:'example.com/websocket/wamp' });
+            ws = getWebSocket({ url:'example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
         });
 
         it('allows to create websocket object with full qualified url', function () {
             global.window.location = { port: '', hostname: 'localhost', protocol: 'http:' };
-            let ws = getWebSocket({ _url:'ws://example.com/websocket/wamp' });
+            let ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '8888', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket({ _url:'ws://example.com/websocket/wamp' });
+            ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ _url:'ws://example.com/websocket/wamp' });
+            ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '1234', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ _url:'ws://example.com/websocket/wamp' });
+            ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket({ _url:'wss://example.com/websocket/wamp' });
+            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             global.window.location = { port: '8888', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket({ _url:'wss://example.com/websocket/wamp' });
+            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ _url:'wss://example.com/websocket/wamp' });
+            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             global.window.location = { port: '1234', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket({ _url:'wss://example.com/websocket/wamp' });
+            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             // Test for returning MozWebSocket in old firefoxes
             delete global.window.WebSocket;
             global.window.MozWebSocket = function (url) { this.name = 'MozWebSocket'; this.url = url; };
-            ws = getWebSocket({ _url:'wss://example.com/websocket/wamp' });
+            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('MozWebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
             delete global.window.MozWebSocket;
@@ -174,7 +174,7 @@ describe('Wampy.js Utils submodule', function () {
 
         it('disallows to create websocket instance if WebSocket object is not available in window', function () {
             delete global.window.WebSocket;
-            expect(getWebSocket({ _url:'ws://example.com/ws/path' })).to.be.null;
+            expect(getWebSocket({ url:'ws://example.com/ws/path' })).to.be.null;
             global.window.WebSocket = function (url) { this.name = 'WebSocket'; this.url = url; };
         });
 
@@ -195,23 +195,23 @@ describe('Wampy.js Utils submodule', function () {
         });
 
         it('allows to create websocket object with just path in url', function () {
-            const ws = getWebSocket({ _url:'/websocket/wamp' });
+            const ws = getWebSocket({ url:'/websocket/wamp' });
 
             expect(ws.url).to.be.equal('ws://localhost:9876/websocket/wamp');
         });
 
         it('allows to create websocket object with domain+path url', function () {
-            const ws = getWebSocket({ _url:'example.com/websocket/wamp' });
+            const ws = getWebSocket({ url:'example.com/websocket/wamp' });
 
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
         });
 
         it('allows to create websocket object with full qualified url', function () {
-            let ws = getWebSocket({ _url:'ws://example.com/websocket/wamp' });
+            let ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
 
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
-            ws = getWebSocket({ _url:'wss://example.com/websocket/wamp' });
+            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
 
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
         });

--- a/test/wampy-utils-test.js
+++ b/test/wampy-utils-test.js
@@ -11,31 +11,14 @@ import { expect } from 'chai';
 import * as utils  from './../src/utils.js';
 let getWebSocket = utils.getWebSocket;
 
-function getPseudoBrowserWebSocket (url, protocols, ws, headers, requestOptions) {
-    const parsedUrl = utils.getServerUrlForBrowser(url);
-
-    if (!parsedUrl) {
-        return null;
-    }
-
-    if (ws) {   // User provided webSocket class
-        return new ws(parsedUrl, protocols, null, headers, requestOptions);
-    } else if ('WebSocket' in window) {
-        // Chrome, MSIE, newer Firefox
-        return new window.WebSocket(parsedUrl, protocols);
-    } else if ('MozWebSocket' in window) {
-        // older versions of Firefox
-        return new window.MozWebSocket(parsedUrl, protocols);
-    }
-
-    return null;
+function getPseudoBrowserWebSocket (options = {}) {
+    return utils.getWebSocket({ ...options, isBrowserMock: true });
 }
 
 describe('Wampy.js Utils submodule', function () {
     this.timeout(0);
 
     describe('In node environment', function () {
-
         if (!isNode) {
             return;
         }
@@ -45,24 +28,24 @@ describe('Wampy.js Utils submodule', function () {
         });
 
         it('disallows to create websocket object without providing full qualified url', function () {
-            expect(getWebSocket('/just/path')).to.be.null;
-            expect(getWebSocket('example.com/')).to.be.null;
-            expect(getWebSocket('example.com:3128/just/path')).to.be.null;
+            expect(getWebSocket({ url: '/just/path' })).to.be.null;
+            expect(getWebSocket({ url: 'example.com/' })).to.be.null;
+            expect(getWebSocket({ url: 'example.com:3128/just/path' })).to.be.null;
         });
 
         it('disallows to create websocket instance without providing websocket class object', function () {
+            const optionsWithoutWsClass = { url:'ws://example.com/ws/path', protocols: ['wamp.2.json'] };
+
+            expect(getWebSocket(optionsWithoutWsClass)).to.be.null;
+
             const wsClass = function (url) { this.name = 'UserWebSocket'; this.url = url; };
+            const optionsWithWsClass = { ...optionsWithoutWsClass, ws: wsClass };
 
-            expect(getWebSocket('ws://example.com/ws/path')).to.be.null;
-
-            const ws = getWebSocket('ws://example.com/ws/path', ['wamp.2.json'], wsClass);
-            expect(ws).to.be.instanceOf(wsClass);
+            expect(getWebSocket(optionsWithWsClass)).to.be.instanceOf(wsClass);
         });
-
     });
 
-    describe('In browser environment (node-mock)', function () {
-
+    describe('In pseudo-browser environment (node-mock)', function () {
         if (!isNode) {
             return;
         }
@@ -96,93 +79,93 @@ describe('Wampy.js Utils submodule', function () {
 
         it('allows to create websocket object with just path in url', function () {
             global.window.location = { port: '', hostname: 'localhost', protocol: 'http:' };
-            let ws = getWebSocket('/websocket/wamp');
+            let ws = getWebSocket({ url: '/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://localhost/websocket/wamp');
 
             global.window.location = { port: '8888', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket('/websocket/wamp');
+            ws = getWebSocket({ url:'/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://localhost:8888/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket('/websocket/wamp');
+            ws = getWebSocket({ url:'/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://localhost/websocket/wamp');
 
             global.window.location = { port: '1234', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket('/websocket/wamp');
+            ws = getWebSocket({ url:'/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://localhost:1234/websocket/wamp');
         });
 
         it('allows to create websocket object with domain+path url', function () {
             global.window.location = { port: '', hostname: 'localhost', protocol: 'http:' };
-            let ws = getWebSocket('example.com/websocket/wamp');
+            let ws = getWebSocket({ url:'example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '8888', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket('example.com/websocket/wamp');
+            ws = getWebSocket({ url:'example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket('example.com/websocket/wamp');
+            ws = getWebSocket({ url:'example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             global.window.location = { port: '1234', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket('example.com/websocket/wamp');
+            ws = getWebSocket({ url:'example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
         });
 
         it('allows to create websocket object with full qualified url', function () {
             global.window.location = { port: '', hostname: 'localhost', protocol: 'http:' };
-            let ws = getWebSocket('ws://example.com/websocket/wamp');
+            let ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '8888', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket('ws://example.com/websocket/wamp');
+            ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket('ws://example.com/websocket/wamp');
+            ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '1234', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket('ws://example.com/websocket/wamp');
+            ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket('wss://example.com/websocket/wamp');
+            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             global.window.location = { port: '8888', hostname: 'localhost', protocol: 'http:' };
-            ws = getWebSocket('wss://example.com/websocket/wamp');
+            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             global.window.location = { port: '', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket('wss://example.com/websocket/wamp');
+            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             global.window.location = { port: '1234', hostname: 'localhost', protocol: 'https:' };
-            ws = getWebSocket('wss://example.com/websocket/wamp');
+            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('WebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
 
             // Test for returning MozWebSocket in old firefoxes
             delete global.window.WebSocket;
             global.window.MozWebSocket = function (url) { this.name = 'MozWebSocket'; this.url = url; };
-            ws = getWebSocket('wss://example.com/websocket/wamp');
+            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
             expect(ws.name).to.be.equal('MozWebSocket');
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
             delete global.window.MozWebSocket;
@@ -191,18 +174,16 @@ describe('Wampy.js Utils submodule', function () {
 
         it('disallows to create websocket instance if WebSocket object is not available in window', function () {
             delete global.window.WebSocket;
-            expect(getWebSocket('ws://example.com/ws/path')).to.be.null;
+            expect(getWebSocket({ url:'ws://example.com/ws/path' })).to.be.null;
             global.window.WebSocket = function (url) { this.name = 'WebSocket'; this.url = url; };
         });
 
         after(function () {
             delete global.window;
         });
-
     });
 
     describe('In browser environment (real)', () => {
-
         if (isNode) {
             return;
         }
@@ -211,34 +192,28 @@ describe('Wampy.js Utils submodule', function () {
             const ws = getWebSocket();
 
             expect(ws.url).to.be.equal('ws://localhost:9876/ws');
-
         });
 
         it('allows to create websocket object with just path in url', function () {
-            const ws = getWebSocket('/websocket/wamp');
+            const ws = getWebSocket({ url:'/websocket/wamp' });
 
             expect(ws.url).to.be.equal('ws://localhost:9876/websocket/wamp');
         });
 
         it('allows to create websocket object with domain+path url', function () {
-
-            const ws = getWebSocket('example.com/websocket/wamp');
+            const ws = getWebSocket({ url:'example.com/websocket/wamp' });
 
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
-
         });
 
         it('allows to create websocket object with full qualified url', function () {
-
-            let ws = getWebSocket('ws://example.com/websocket/wamp');
+            let ws = getWebSocket({ url:'ws://example.com/websocket/wamp' });
 
             expect(ws.url).to.be.equal('ws://example.com/websocket/wamp');
 
-            ws = getWebSocket('wss://example.com/websocket/wamp');
+            ws = getWebSocket({ url:'wss://example.com/websocket/wamp' });
 
             expect(ws.url).to.be.equal('wss://example.com/websocket/wamp');
-
         });
     });
-
 });


### PR DESCRIPTION
### Description, Motivation and Context
- Refactor `utils.getWebSocket` so it's easier to unit test;
- Move logic from `utils.getWebSocket` that checked for the browser's Window Object into a new function `utils.getWebSocketFromWindowObject`;
- Add jsdoc comments to functions `utils.getWebSocket` and `utils.getWebSocketFromWindowObject`;

### What kind of change does this PR introduce?
- [x] Refactoring (no new functionality, only code improvements)

### Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
