### PR TITLE
Remove unused this._ws check from _initWsCallbacks

### DIFF
--- a/src/wampy.js
+++ b/src/wampy.js
@@ -772,8 +772,6 @@ class Wampy {
      * @private
      */
     _initWsCallbacks () {
-        if (!this._ws) { return; }
-
         this._ws.onopen = () => this._wsOnOpen();
         this._ws.onclose = (event) => this._wsOnClose(event);
         this._ws.onmessage = (event) => this._wsOnMessage(event);


### PR DESCRIPTION
### Description, Motivation and Context
This code is never reached since function `connect()` already checks for `this._ws` before safely calling `_initWsCallbacks()`;
Also, in case there was no `this._ws` I'd prefer a runtime error over silently failing and returning with no error message

### What kind of change does this PR introduce?
- [x] Refactoring (no new functionality, only code improvements)

### Checklist:
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
