### PR TITLE
Remove unncessary default values to improve test coverage

### DIFF
--- a/src/wampy.js
+++ b/src/wampy.js
@@ -566,7 +566,7 @@ class Wampy {
         }
 
         const isPayloadAnObject = this._isPlainObject(payload);
-        const { argsList, argsDict } = payload || {};
+        const { argsList, argsDict } = payload;
         let args, kwargs;
 
         if (isPayloadAnObject && !argsList && !argsDict) {
@@ -616,11 +616,12 @@ class Wampy {
             }
         }
 
+        // TODO: implement End-to-End Encryption
         // wamp scheme means Payload End-to-End Encryption
         // @see https://wamp-proto.org/wamp_latest_ietf.html#name-payload-end-to-end-encrypti
-        if (options.ppt_scheme === 'wamp') {
-            // TODO: implement End-to-End Encryption
-        }
+        // if (options.ppt_scheme === 'wamp') {
+        //
+        // }
 
         payloadItems.push([binPayload]);
 
@@ -642,13 +643,12 @@ class Wampy {
             return { err: this._cache.opStatus.error };
         }
 
+        // TODO: implement End-to-End Encryption
         // wamp scheme means Payload End-to-End Encryption
         // @see https://wamp-proto.org/wamp_latest_ietf.html#name-payload-end-to-end-encrypti
-        if (options.ppt_scheme === 'wamp') {
-
-            // TODO: implement End-to-End Encryption
-
-        }
+        // if (options.ppt_scheme === 'wamp') {
+        //
+        // }
 
         if (options.ppt_serializer && options.ppt_serializer !== 'native') {
             const pptSerializer = this._options.payloadSerializers[options.ppt_serializer];
@@ -1077,7 +1077,7 @@ class Wampy {
             return;
         }
 
-        const { topic, advancedOptions, callbacks } = this._requests[requestId] || {};
+        const { topic, advancedOptions, callbacks } = this._requests[requestId];
         const subscription = {
             id: subscriptionId,
             topic,
@@ -1108,7 +1108,7 @@ class Wampy {
             return;
         }
 
-        const { topic, advancedOptions, callbacks } = this._requests[requestId] || {};
+        const { topic, advancedOptions, callbacks } = this._requests[requestId];
         const subscriptionKey = this._getSubscriptionKey(topic, advancedOptions);
         const subscriptionId = this._subscriptionsByKey.get(subscriptionKey).id;
         this._subscriptionsByKey.delete(subscriptionKey);
@@ -1349,8 +1349,8 @@ class Wampy {
         }
 
         const handleInvocationResult = (result) => {
-            const options = result?.options;
-            const { ppt_scheme, ppt_serializer, ppt_cipher, ppt_keyid } = options ?? {};
+            const options = result?.options || {};
+            const { ppt_scheme, ppt_serializer, ppt_cipher, ppt_keyid } = options;
 
             // Check and handle Payload PassThru Mode
             // @see https://wamp-proto.org/wamp_latest_ietf.html#name-payload-passthru-mode
@@ -1368,7 +1368,7 @@ class Wampy {
                 });
             }
 
-            const { err, payloadItems } = result ? this._packPPTPayload(result, options || {}) : {};
+            const { err, payloadItems } = result ? this._packPPTPayload(result, options) : {};
 
             if (err) {
                 return handleInvocationError({
@@ -1379,7 +1379,7 @@ class Wampy {
             }
 
             const messageOptions = {
-                ...(options || {}),
+                ...options,
                 ...(ppt_scheme ? { ppt_scheme } : {}),
                 ...(ppt_serializer ? { ppt_serializer } : {}),
                 ...(ppt_cipher ? { ppt_cipher } : {}),
@@ -1834,7 +1834,7 @@ class Wampy {
 
         messageOptions = {
             acknowledge: true,
-            ...(messageOptions || {}),
+            ...messageOptions,
             ...(ppt_scheme ? { ppt_scheme } : {}),
             ...(ppt_scheme ? { ppt_scheme } : {}),
             ...(ppt_serializer ? { ppt_serializer } : {}),


### PR DESCRIPTION
### Description, Motivation and Context
- Remove unnecessary default values for previously defined variables (and therefore never falsy) such as `options`, and `payload`;
- Remove unnecessary default values for conditions that previously triggered a `{ return; }` block and therefore were not reachable, such as checking for `this._requests[requestId]` after a block that already exited if it was falsy;
- Comment out unimplemented `if` blocks such as the ones for implementing End-to-End Encryption;

### What kind of change does this PR introduce?
- [x] Refactoring (no new functionality, only code improvements)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] Overall test coverage is not decreased.
- [ ] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
