### PR TITLE
Adapt wampy-utils-test.js to the getWebSocket refactor

### DIFF
--- a/test/wampy-utils-test.js
+++ b/test/wampy-utils-test.js
@@ -22,25 +22,28 @@ describe('Wampy.js Utils submodule', function () {
             return;
         }
 
-        it('disallows to create websocket object without providing url', function () {
+        const protocols = ['wamp.2.json'];
+        const qualifiedUrl = 'ws://example.com/ws/path';
+        const ws = function (url) { this.name = 'UserWebSocket'; this.url = url; };
+
+        it('disallows to create websocket object without providing a websocket class object', function () {
             expect(getWebSocket()).to.be.null;
+            expect(getWebSocket({})).to.be.null;
+            expect(getWebSocket({ protocols })).to.be.null;
+            expect(getWebSocket({ protocols, url: qualifiedUrl })).to.be.null;
         });
 
-        it('disallows to create websocket object without providing full qualified url', function () {
-            expect(getWebSocket({ url: '/just/path' })).to.be.null;
-            expect(getWebSocket({ url: 'example.com/' })).to.be.null;
-            expect(getWebSocket({ url: 'example.com:3128/just/path' })).to.be.null;
+        it('disallows to create websocket object without providing a fully qualified url', function () {
+            expect(getWebSocket({ options: { ws } })).to.be.null;
+            expect(getWebSocket({ options: { ws }, protocols })).to.be.null;
+            expect(getWebSocket({ options: { ws }, protocols, url: '/just/path' })).to.be.null;
+            expect(getWebSocket({ options: { ws }, protocols, url: 'example.com/' })).to.be.null;
+            expect(getWebSocket({ options: { ws }, protocols, url: 'example.com:3128/just/path' })).to.be.null;
         });
 
-        it('disallows to create websocket instance without providing websocket class object', function () {
-            const configWithoutWsClass = { url:'ws://example.com/ws/path', protocols: ['wamp.2.json'] };
-
-            expect(getWebSocket(configWithoutWsClass)).to.be.null;
-
-            const wsClass = function (url) { this.name = 'UserWebSocket'; this.url = url; };
-            const configWithWsClass = { ...configWithoutWsClass, options: { ws: wsClass } };
-
-            expect(getWebSocket(configWithWsClass)).to.be.instanceOf(wsClass);
+        it('allows to create websocket object when ws class and fully qualified url are provided', function () {
+            expect(getWebSocket({ options: { ws }, url: qualifiedUrl  })).to.be.instanceOf(ws);
+            expect(getWebSocket({ options: { ws }, protocols, url: qualifiedUrl })).to.be.instanceOf(ws);
         });
     });
 


### PR DESCRIPTION
### Description, Motivation and Context
After #249, tests needed to be rewritten a bit for full 100% utils.js branch coverage.

### What is the current behavior?
Particularly the `if (!parsedUrl)` check is no longer being tested, since the `if (!ws && isActualNode)` condition is now executed before it.

### What is the new behavior?
Now, tests cover all branches and statements and also a few more edge cases, just to be sure.

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactoring (no new functionality, only code improvements)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
