### PR TITLE
Remove "-undefined" suffix when no options are provided for subscription

### DIFF
--- a/src/wampy.js
+++ b/src/wampy.js
@@ -1500,7 +1500,7 @@ class Wampy {
      * @private
      */
     _getSubscriptionKey (topic, options) {
-        return `${topic}-${JSON.stringify(options)}`;
+        return `${topic}${options ? `-${JSON.stringify(options)}` : ''}`;
     }
 
     /*************************************************************************

--- a/test/wampy-common-test.js
+++ b/test/wampy-common-test.js
@@ -1372,7 +1372,7 @@ serializers.forEach(function (item) {
             });
 
             it('allows to unsubscribe all handlers from topic', async function () {
-                await wampy.unsubscribe('subscribe.topic9-undefined');
+                await wampy.unsubscribe('subscribe.topic9');
                 expect(wampy.getOpStatus().code).to.be.equal(SUCCESS.code);
             });
 
@@ -1395,7 +1395,7 @@ serializers.forEach(function (item) {
 
             it('fires error callback if error occurred during unsubscribing', async function () {
                 try {
-                    await wampy.unsubscribe('subscribe.topic3-undefined');
+                    await wampy.unsubscribe('subscribe.topic3');
                 } catch (e) {
                     expect(e).to.be.instanceOf(Errors.UnsubscribeError);
                 }


### PR DESCRIPTION
This avoids keys such as "topic-undefined" when no subscription options are passed

### What kind of change does this PR introduce?
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no new functionality, only code improvements)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] Overall test coverage is not decreased.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
