### PR TITLE
ci(dependabot): group npm updates into prod/dev grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,22 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
+# Dependabot configuration for automated dependency updates.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Combine non-major updates into a couple of grouped PRs to cut down on noise.
+    # Major bumps are intentionally left out of the groups so each gets its own PR
+    # for individual review.
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## What

Adds `groups` to `.github/dependabot.yml` so Dependabot bundles non-major npm updates into **two grouped PRs** instead of one PR per dependency:

- **production-dependencies** — runtime deps (`ws`, `msgpackr`, `cbor-x`, …), minor + patch
- **development-dependencies** — dev tooling (`eslint`, `mocha`, `tsx`, `@types/*`, …), minor + patch

**Major** version bumps are intentionally left out of the groups, so each major still gets its own PR for individual review.

## Why

Currently every dependency bump opens a separate PR (5 open right now). Grouping cuts PR noise and CI runs while keeping runtime updates separate from dev-tooling updates.

## After merge

Once this lands on `dev` (the branch Dependabot targets), the next Dependabot run will supersede the existing individual PRs (#649, #650, #651, #652, #653) and open the grouped PRs instead. Merge a grouped PR with **Squash and merge** to land it as a single commit.